### PR TITLE
Switched to https://min-api.cryptocompare.com/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Switched to https://min-api.cryptocompare.com/
 - added: `histoHour()`
 - added: `histoMinute()`
 - added: `generateAvg()`
+- added: `exchanges` option for methods that support it
 
 0.0.2 / 2016-11-21
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Switched to https://min-api.cryptocompare.com/
 - added: `priceFull()`
 - added: `topPairs()`
 - added: `topExchanges()`
+- added: `histoDay()`
 
 0.0.2 / 2016-11-21
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Switched to https://min-api.cryptocompare.com/
 - added: `histoDay()`
 - added: `histoHour()`
 - added: `histoMinute()`
+- added: `generateAvg()`
 
 0.0.2 / 2016-11-21
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Switched to https://min-api.cryptocompare.com/
 - changed: `priceHistorical()` returns a different data structure
 - added: `priceMulti()`
 - added: `priceFull()`
+- added: `topPairs()`
 
 0.0.2 / 2016-11-21
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Switched to https://min-api.cryptocompare.com/
 - changed: `price()` returns a different data structure
 - changed: `priceHistorical()` returns a different data structure
 - added: `priceMulti()`
+- added: `priceFull()`
 
 0.0.2 / 2016-11-21
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Switched to https://min-api.cryptocompare.com/
 - added: `topPairs()`
 - added: `topExchanges()`
 - added: `histoDay()`
+- added: `histoHour()`
 
 0.0.2 / 2016-11-21
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Unreleased
 ----------
 
+Switched to https://min-api.cryptocompare.com/
+
+- removed: `coinList()`
+- changed: `price()` returns a different data structure
+- changed: `priceHistorical()` returns a different data structure
+
 0.0.2 / 2016-11-21
 ------------------
 - bug fix: `priceHistorical()` - wrong endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Switched to https://min-api.cryptocompare.com/
 - removed: `coinList()`
 - changed: `price()` returns a different data structure
 - changed: `priceHistorical()` returns a different data structure
+- changed: `price()` and `priceHistorical)()` function signature has changed
 - added: `priceMulti()`
 - added: `priceFull()`
 - added: `topPairs()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Switched to https://min-api.cryptocompare.com/
 - removed: `coinList()`
 - changed: `price()` returns a different data structure
 - changed: `priceHistorical()` returns a different data structure
+- added: `priceMulti()`
 
 0.0.2 / 2016-11-21
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Switched to https://min-api.cryptocompare.com/
 - added: `priceMulti()`
 - added: `priceFull()`
 - added: `topPairs()`
+- added: `topExchanges()`
 
 0.0.2 / 2016-11-21
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Switched to https://min-api.cryptocompare.com/
 - added: `topExchanges()`
 - added: `histoDay()`
 - added: `histoHour()`
+- added: `histoMinute()`
 
 0.0.2 / 2016-11-21
 ------------------

--- a/README.md
+++ b/README.md
@@ -84,6 +84,54 @@ cc.priceMulti('BTC', 'USD')
 .catch(console.error)
 ```
 
+### `priceFull()`
+
+Get all the current trading info (price, vol, open, high, low etc) of any list of cryptocurrencies in any other currency.
+
+`priceFull(fsym, tsyms[, tryConversion])`
+
+- `fsyms` (Array of Strings | String) From Symbol(s)
+- `tsyms` (Array of Strings | String) To Symbol(s)
+- `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
+
+```js
+const cc = require('cryptocompare')
+
+cc.priceFull(['BTC', 'ETH'], ['USD', 'EUR'])
+.then(prices => {
+  console.log(prices)
+  // {
+  //   BTC: {
+  //     USD: {
+  //       TYPE: '5',
+  //       MARKET: 'CCCAGG',
+  //       FROMSYMBOL: 'BTC',
+  //       TOSYMBOL: 'USD',
+  //       FLAGS: '4',
+  //       PRICE: 1152.42,
+  //       LASTUPDATE: 1487865689,
+  //       LASTVOLUME: 0.21,
+  //       LASTVOLUMETO: 242.20349999999996,
+  //       LASTTRADEID: 1224703,
+  //       VOLUME24HOUR: 53435.45299122338,
+  //       VOLUME24HOURTO: 60671593.843186244,
+  //       OPEN24HOUR: 1119.31,
+  //       HIGH24HOUR: 1170,
+  //       LOW24HOUR: 1086.641,
+  //       LASTMARKET: 'itBit',
+  //       CHANGE24HOUR: 33.11000000000013,
+  //       CHANGEPCT24HOUR: 2.958072383879366,
+  //       SUPPLY: 16177825,
+  //       MKTCAP: 18643649086.5
+  //     },
+  //     EUR: ...
+  //   },
+  //   ETH: ...
+  // }
+})
+.catch(console.error)
+```
+
 ### priceHistorical
 
 `priceHistorical(fsym, tsyms, time[, tryConversion])`

--- a/README.md
+++ b/README.md
@@ -227,6 +227,36 @@ cc.topExchanges('BTC', 'USD', 2)
 .catch(console.error)
 ```
 
+### `histoDay()`
+
+Get open, high, low, close, volumefrom and volumeto from the daily historical data. The values are based on 00:00 GMT time.
+
+`histoDay(fsym, tsym[, options])`
+
+- `fsym` (String) From Symbol
+- `tsym` (String) To Symbol
+- `options` (Object)
+  - `aggregate` (Number) Number of data points to aggregate.
+  - `limit` (Number | `'none'`) Limit the number of days to lookup. Default is 30. If you set it to the string `'none'`, you will get all available data.
+  - `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
+  - `timestamp` (Date) By default, `histoDay()` gets historical data for the past several days. Use the `timestamp` option to set a historical start point.
+
+```js
+cc.histoDay('BTC', 'USD')
+.then(data => {
+  console.log(data)
+  // -> [ { time: 1485388800,
+  //        close: 915.65,
+  //        high: 917.71,
+  //        low: 893.81,
+  //        open: 893.97,
+  //        volumefrom: 35494.93,
+  //        volumeto: 32333344.2 },
+  //        ... ]
+})
+.catch(console.error)
+```
+
 ## License
 
 [MIT](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ Usage
 
 Get the current price of any cryptocurrency in any other currency.
 
-`price(fsym, tsyms[, tryConversion])`
+`price(fsym, tsyms[, options])`
 
 - `fsym` (String) From Symbol
 - `tsyms` (Array of Strings | String) To Symbol(s)
-- `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
+- `options` (Object)
+  - `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
 
 ```js
 const cc = require('cryptocompare')
@@ -70,11 +71,12 @@ cc.price('BTC', 'USD')
 
 Works like `price()`, except it allows you to specify a matrix of From Symbols.
 
-`priceMulti(fsyms, tsyms[, tryConversion])`
+`priceMulti(fsyms, tsyms[, options])`
 
 - `fsyms` (Array of Strings | String) From Symbol(s)
 - `tsyms` (Array of Strings | String) To Symbol(s)
-- `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
+- `options` (Object)
+  - `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
 
 ```js
 const cc = require('cryptocompare')
@@ -101,11 +103,12 @@ cc.priceMulti('BTC', 'USD')
 
 Get all the current trading info (price, vol, open, high, low, etc.) of any list of cryptocurrencies in any other currency.
 
-`priceFull(fsyms, tsyms[, tryConversion])`
+`priceFull(fsyms, tsyms[, options])`
 
 - `fsyms` (Array of Strings | String) From Symbol(s)
 - `tsyms` (Array of Strings | String) To Symbol(s)
-- `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
+- `options` (Object)
+  - `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
 
 ```js
 const cc = require('cryptocompare')
@@ -149,12 +152,13 @@ cc.priceFull(['BTC', 'ETH'], ['USD', 'EUR'])
 
 Get the price of any cryptocurrency in any other currency at a given timestamp. The price comes from the daily info - so it would be the price at the end of the day GMT based on the requested timestamp.
 
-`priceHistorical(fsym, tsyms, time[, tryConversion])`
+`priceHistorical(fsym, tsyms, time[, options])`
 
 - `fsym` (String) From Symbol
 - `tsyms` (Array of Strings | String) To Symbol(s)
 - `time` (Date) Date in history that you want price data for
-- `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
+- `options` (Object)
+  - `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
 
 ```js
 const cc = require('cryptocompare')

--- a/README.md
+++ b/README.md
@@ -197,6 +197,36 @@ cc.topPairs('BTC', 2)
 .catch(console.error)
 ```
 
+### `topExchanges()`
+
+Get top exchanges by volume for a currency pair.
+
+`topExchanges(fsym, tsym[, limit])`
+
+- `fsym` (String) From Symbol
+- `tsym` (String) To Symbol
+- `limit` (Number) Limit the number of exchanges you receive (default 5).
+
+```js
+const cc = require('cryptocompare')
+
+cc.topExchanges('BTC', 'USD', 2)
+.then(exchanges => {
+  console.log(exchanges)
+  // -> [ { exchange: 'Bitfinex',
+  //        fromSymbol: 'BTC',
+  //        toSymbol: 'USD',
+  //        volume24h: 35239.36701090003,
+  //        volume24hTo: 41472258.85534388 },
+  //      { exchange: 'Bitstamp',
+  //        fromSymbol: 'BTC',
+  //        toSymbol: 'USD',
+  //        volume24h: 19658.748675010014,
+  //        volume24hTo: 23047071.74260772 } ]
+})
+.catch(console.error)
+```
+
 ## License
 
 [MIT](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Usage
 
 ### `price()`
 
-`price(fsym, tsyms, [tryConversion])`
+`price(fsym, tsyms[, tryConversion])`
 
 - `fsym` (String) From Symbol
 - `tsym` (Array of Strings | String) To Symbol(s)
@@ -55,11 +55,12 @@ cc.price('BTC', 'USD')
 
 ### priceHistorical
 
-`priceHistorical(fsym, tsyms, time)`
+`priceHistorical(fsym, tsyms, time[, tryConversion])`
 
 - `fsym` (String) From Symbol
 - `tsym` (Array of Strings | String) To Symbol(s)
 - `time` (Date) Date in history that you want price data for
+- `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
 
 ```js
 const cc = require('cryptocompare')

--- a/README.md
+++ b/README.md
@@ -23,14 +23,27 @@ Install
 Usage
 -----
 
+**Note:** cryptocompare depends on [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) being defined globally.
+
+- If you are using this in electron, it should work without any configuration.
+- If you are using this in Node.js, you will need to use [`node-fetch`](https://www.npmjs.com/package/node-fetch).
+
+  **Example:**
+  ```js
+  global.fetch = require('node-fetch')
+  const cc = require('cryptocompare')
+  ```
+
 ### Methods
 
 ### `price()`
 
+Get the current price of any cryptocurrency in any other currency.
+
 `price(fsym, tsyms[, tryConversion])`
 
 - `fsym` (String) From Symbol
-- `tsym` (Array of Strings | String) To Symbol(s)
+- `tsyms` (Array of Strings | String) To Symbol(s)
 - `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
 
 ```js
@@ -57,7 +70,7 @@ cc.price('BTC', 'USD')
 
 Works like `price()`, except it allows you to specify a matrix of From Symbols.
 
-`priceMulti(fsym, tsyms[, tryConversion])`
+`priceMulti(fsyms, tsyms[, tryConversion])`
 
 - `fsyms` (Array of Strings | String) From Symbol(s)
 - `tsyms` (Array of Strings | String) To Symbol(s)
@@ -86,9 +99,9 @@ cc.priceMulti('BTC', 'USD')
 
 ### `priceFull()`
 
-Get all the current trading info (price, vol, open, high, low etc) of any list of cryptocurrencies in any other currency.
+Get all the current trading info (price, vol, open, high, low, etc.) of any list of cryptocurrencies in any other currency.
 
-`priceFull(fsym, tsyms[, tryConversion])`
+`priceFull(fsyms, tsyms[, tryConversion])`
 
 - `fsyms` (Array of Strings | String) From Symbol(s)
 - `tsyms` (Array of Strings | String) To Symbol(s)
@@ -132,12 +145,14 @@ cc.priceFull(['BTC', 'ETH'], ['USD', 'EUR'])
 .catch(console.error)
 ```
 
-### priceHistorical
+### `priceHistorical()`
+
+Get the price of any cryptocurrency in any other currency at a given timestamp. The price comes from the daily info - so it would be the price at the end of the day GMT based on the requested timestamp.
 
 `priceHistorical(fsym, tsyms, time[, tryConversion])`
 
 - `fsym` (String) From Symbol
-- `tsym` (Array of Strings | String) To Symbol(s)
+- `tsyms` (Array of Strings | String) To Symbol(s)
 - `time` (Date) Date in history that you want price data for
 - `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Get the current price of any cryptocurrency in any other currency.
 - `tsyms` (Array of Strings | String) To Symbol(s)
 - `options` (Object)
   - `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
+  - `exchanges` (Array of Strings | Array) Exchanges to get price data from. By default, average data is used. (You can get a list of top exchanges for a given pair with `topExchanges()`.)
 
 ```js
 const cc = require('cryptocompare')
@@ -77,6 +78,7 @@ Works like `price()`, except it allows you to specify a matrix of From Symbols.
 - `tsyms` (Array of Strings | String) To Symbol(s)
 - `options` (Object)
   - `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
+  - `exchanges` (Array of Strings | Array) Exchanges to get price data from. By default, average data is used. (You can get a list of top exchanges for a given pair with `topExchanges()`.)
 
 ```js
 const cc = require('cryptocompare')
@@ -109,6 +111,7 @@ Get all the current trading info (price, vol, open, high, low, etc.) of any list
 - `tsyms` (Array of Strings | String) To Symbol(s)
 - `options` (Object)
   - `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
+  - `exchanges` (Array of Strings | Array) Exchanges to get price data from. By default, average data is used. (You can get a list of top exchanges for a given pair with `topExchanges()`.)
 
 ```js
 const cc = require('cryptocompare')
@@ -159,6 +162,7 @@ Get the price of any cryptocurrency in any other currency at a given timestamp. 
 - `time` (Date) Date in history that you want price data for
 - `options` (Object)
   - `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
+  - `exchanges` (Array of Strings | Array) Exchanges to get price data from. By default, average data is used. (You can get a list of top exchanges for a given pair with `topExchanges()`.)
 
 ```js
 const cc = require('cryptocompare')

--- a/README.md
+++ b/README.md
@@ -25,51 +25,53 @@ Usage
 
 ### Methods
 
-#### coinList
+### `price()`
 
-Reference: https://www.cryptocompare.com/api/#-api-data-coinlist-
+`price(fsym, tsyms, [tryConversion])`
 
-- Signature: `coinList()`
-- Parameters: (none)           
-- Returns:    A Promise function that returns contains an associative array of coins.
-
-**Example:**
+- `fsym` (String) From Symbol
+- `tsym` (Array of Strings | String) To Symbol(s)
+- `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
 
 ```js
-var cc = require('cryptocompare')
-cc.coinList()
-.then(coinList => {
-  console.dir(coinList.BTC)
+const cc = require('cryptocompare')
+
+// Basic Usage:
+cc.price('BTC', ['USD', 'EUR'])
+.then(prices => {
+  console.log(prices)
+  // -> { USD: 1100.24, EUR: 1039.63 }
 })
-.catch(console.error.bind(console)
+.catch(console.error)
+
+// Passing a single pair of currencies:
+cc.price('BTC', 'USD')
+.then(prices => {
+  console.log(prices)
+  // -> { USD: 1100.24 }
+})
+.catch(console.error)
 ```
-
-**Outputs:**
-
-```
-{ Id: '1182',
-  Url: '/coins/btc/overview',
-  ImageUrl: '/media/19633/btc.png',
-  Name: 'BTC',
-  CoinName: 'Bitcoin',
-  FullName: 'Bitcoin (BTC)',
-  Algorithm: 'SHA256',
-  ProofType: 'PoW',
-  FullyPremined: '0',
-  TotalCoinSupply: '21000000',
-  PreMinedValue: 'N/A',
-  TotalCoinsFreeFloat: 'N/A',
-  SortOrder: '1' }
-```
-
-### price
-
-Reference: https://www.cryptocompare.com/api/#-api-data-price-
-
 
 ### priceHistorical
 
-https://www.cryptocompare.com/api/#-api-data-pricehistorical-
+`priceHistorical(fsym, tsyms, time)`
+
+- `fsym` (String) From Symbol
+- `tsym` (Array of Strings | String) To Symbol(s)
+- `time` (Date) Date in history that you want price data for
+
+```js
+const cc = require('cryptocompare')
+
+// Basic Usage:
+cc.priceHistorical('BTC', ['USD', 'EUR'], new Date('2017-01-01'))
+.then(prices => {
+  console.log(prices)
+  // -> { BTC: { USD: 997, EUR: 948.17 } }
+})
+.catch(console.error)
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,45 @@ cc.priceHistorical('BTC', ['USD', 'EUR'], new Date('2017-01-01'))
 .catch(console.error)
 ```
 
+### `generateAvg()`
+
+Compute the current trading info (price, vol, open, high, low etc) of the requested pair as a volume weighted average based on the markets requested.
+
+`generateAvg(fsym, tsym, markets[, tryConversion])`
+
+- `fsym` (String) From Symbol
+- `tsym` (String) To Symbol
+- `markets` (Array) Array of markets to base the average on. (You can get a list of top exchanges for a given pair with `topExchanges()`.)
+- `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
+
+```js
+const cc = require('cryptocompare')
+
+// Basic Usage:
+cc.generateAvg('BTC', 'USD', ['Coinbase', 'Kraken', 'Bitstamp', 'Bitfinex'])
+.then(data => {
+  console.log(data)
+  // -> { MARKET: 'CUSTOMAGG',
+  //      FROMSYMBOL: 'BTC',
+  //      TOSYMBOL: 'USD',
+  //      FLAGS: '2',
+  //      PRICE: 1155.61,
+  //      LASTUPDATE: 1488059738,
+  //      LASTVOLUME: 0.25546663,
+  //      LASTVOLUMETO: 294.93622433499996,
+  //      LASTTRADEID: 26533969,
+  //      VOLUME24HOUR: 27318.892083369985,
+  //      VOLUME24HOURTO: 31652183.38370657,
+  //      OPEN24HOUR: 1177.16,
+  //      HIGH24HOUR: 1189.9,
+  //      LOW24HOUR: 1110,
+  //      LASTMARKET: 'Bitfinex',
+  //      CHANGE24HOUR: -21.550000000000182,
+  //      CHANGEPCT24HOUR: -1.830677223147251 }
+})
+.catch(console.error)
+```
+
 ### `topPairs()`
 
 Get top pairs by volume for a currency.

--- a/README.md
+++ b/README.md
@@ -153,9 +153,34 @@ cc.priceHistorical('BTC', ['USD', 'EUR'], new Date('2017-01-01'))
 .catch(console.error)
 ```
 
+### `topPairs()`
 
+Get top pairs by volume for a currency.
 
+`topPairs(fsym[, limit])`
 
+- `fsym` (String) From Symbol
+- `limit` (Number) Limit the number of pairs you receive (default 5).
+
+```js
+const cc = require('cryptocompare')
+
+cc.topPairs('BTC', 2)
+.then(pairs => {
+  console.log(pairs)
+  // -> [ { exchange: 'CCCAGG',
+  //        fromSymbol: 'BTC',
+  //        toSymbol: 'JPY',
+  //        volume24h: 235602.43493487104,
+  //        volume24hTo: 31888554862.766888 },
+  //      { exchange: 'CCCAGG',
+  //        fromSymbol: 'BTC',
+  //        toSymbol: 'USD',
+  //        volume24h: 124504.4477389583,
+  //        volume24hTo: 145514032.93780443 } ]
+})
+.catch(console.error)
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,36 @@ cc.histoHour('BTC', 'USD')
 .catch(console.error)
 ```
 
+### `histoMinute()`
+
+Get open, high, low, close, volumefrom and volumeto from the minute-by-minute historical data.
+
+`histoMinute(fsym, tsym[, options])`
+
+- `fsym` (String) From Symbol
+- `tsym` (String) To Symbol
+- `options` (Object)
+  - `aggregate` (Number) Number of data points to aggregate.
+  - `limit` (Number) Limit the number of minutes to lookup. Default is 1440.
+  - `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
+  - `timestamp` (Date) By default, `histoMinute()` gets historical data for the past several minutes. Use the `timestamp` option to set a historical start point.
+
+```js
+cc.histoMinute('BTC', 'USD')
+.then(data => {
+  console.log(data)
+  // -> [ { time: 1487970960,
+  //        close: 1171.97,
+  //        high: 1172.72,
+  //        low: 1171.97,
+  //        open: 1172.37,
+  //        volumefrom: 25.06,
+  //        volumeto: 29324.12 },
+  //        ... ]
+})
+.catch(console.error)
+```
+
 ## License
 
 [MIT](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,37 @@ cc.price('BTC', 'USD')
 .catch(console.error)
 ```
 
+### `priceMulti()`
+
+Works like `price()`, except it allows you to specify a matrix of From Symbols.
+
+`priceMulti(fsym, tsyms[, tryConversion])`
+
+- `fsyms` (Array of Strings | String) From Symbol(s)
+- `tsyms` (Array of Strings | String) To Symbol(s)
+- `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
+
+```js
+const cc = require('cryptocompare')
+
+// Basic Usage:
+cc.priceMulti(['BTC', 'ETH'], ['USD', 'EUR'])
+.then(prices => {
+  console.log(prices)
+  // -> { BTC: { USD: 1114.63, EUR: 1055.82 },
+  //      ETH: { USD: 12.74, EUR: 12.06 } }
+})
+.catch(console.error)
+
+// Passing a single pair of currencies:
+cc.priceMulti('BTC', 'USD')
+.then(prices => {
+  console.log(prices)
+  // -> { BTC: { USD: 1114.63 } }
+})
+.catch(console.error)
+```
+
 ### priceHistorical
 
 `priceHistorical(fsym, tsyms, time[, tryConversion])`

--- a/README.md
+++ b/README.md
@@ -257,6 +257,36 @@ cc.histoDay('BTC', 'USD')
 .catch(console.error)
 ```
 
+### `histoHour()`
+
+Get open, high, low, close, volumefrom and volumeto from the hourly historical data.
+
+`histoHour(fsym, tsym[, options])`
+
+- `fsym` (String) From Symbol
+- `tsym` (String) To Symbol
+- `options` (Object)
+  - `aggregate` (Number) Number of data points to aggregate.
+  - `limit` (Number) Limit the number of hours to lookup. Default is 168.
+  - `tryConversion` (Boolean) By default, if the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion. Set `tryConversion` to `false` to disable using BTC for conversion.
+  - `timestamp` (Date) By default, `histoHour()` gets historical data for the past several hours. Use the `timestamp` option to set a historical start point.
+
+```js
+cc.histoHour('BTC', 'USD')
+.then(data => {
+  console.log(data)
+  // -> [ { time: 1487448000,
+  //        close: 1060.34,
+  //        high: 1061.44,
+  //        low: 1058.85,
+  //        open: 1059.24,
+  //        volumefrom: 739.6,
+  //        volumeto: 790019.22 },
+  //        ... ]
+})
+.catch(console.error)
+```
+
 ## License
 
 [MIT](LICENSE.md)

--- a/index.js
+++ b/index.js
@@ -18,6 +18,12 @@ function price (fsym, tsyms, tryConversion) {
   return fetchJSON(url)
 }
 
+function priceMulti (fsyms, tsyms, tryConversion) {
+  let url = `${baseUrl}pricemulti?fsyms=${fsyms}&tsyms=${tsyms}`
+  if (tryConversion === false) url += '&tryConversion=false'
+  return fetchJSON(url)
+}
+
 function priceHistorical (fsym, tsyms, time, tryConversion) {
   if (!(time instanceof Date)) throw new Error('time parameter must be an instance of Date.')
   time = Math.floor(time.getTime() / 1000)
@@ -29,5 +35,6 @@ function priceHistorical (fsym, tsyms, time, tryConversion) {
 
 module.exports = {
   price,
+  priceMulti,
   priceHistorical
 }

--- a/index.js
+++ b/index.js
@@ -40,9 +40,16 @@ function priceHistorical (fsym, tsyms, time, tryConversion) {
   return fetchJSON(url).then(result => result[fsym])
 }
 
+function topPairs (fsym, limit) {
+  let url = `${baseUrl}top/pairs?fsym=${fsym}`
+  if (limit) url += `&limit=${limit}`
+  return fetchJSON(url).then(result => result.Data)
+}
+
 module.exports = {
   price,
   priceMulti,
   priceFull,
-  priceHistorical
+  priceHistorical,
+  topPairs
 }

--- a/index.js
+++ b/index.js
@@ -12,29 +12,33 @@ function fetchJSON (url) {
     })
 }
 
-function price (fsym, tsyms, tryConversion) {
+function price (fsym, tsyms, options) {
+  options = options || {}
   let url = `${baseUrl}price?fsym=${fsym}&tsyms=${tsyms}`
-  if (tryConversion === false) url += '&tryConversion=false'
+  if (options.tryConversion === false) url += '&tryConversion=false'
   return fetchJSON(url)
 }
 
-function priceMulti (fsyms, tsyms, tryConversion) {
+function priceMulti (fsyms, tsyms, options) {
+  options = options || {}
   let url = `${baseUrl}pricemulti?fsyms=${fsyms}&tsyms=${tsyms}`
-  if (tryConversion === false) url += '&tryConversion=false'
+  if (options.tryConversion === false) url += '&tryConversion=false'
   return fetchJSON(url)
 }
 
-function priceFull (fsyms, tsyms, tryConversion) {
+function priceFull (fsyms, tsyms, options) {
+  options = options || {}
   let url = `${baseUrl}pricemultifull?fsyms=${fsyms}&tsyms=${tsyms}`
-  if (tryConversion === false) url += '&tryConversion=false'
+  if (options.tryConversion === false) url += '&tryConversion=false'
   // We want the RAW data, not the DISPLAY data:
   return fetchJSON(url).then(result => result.RAW)
 }
 
-function priceHistorical (fsym, tsyms, time, tryConversion) {
+function priceHistorical (fsym, tsyms, time, options) {
+  options = options || {}
   time = dateToTimestamp(time)
   let url = `${baseUrl}pricehistorical?fsym=${fsym}&tsyms=${tsyms}&ts=${time}`
-  if (tryConversion === false) url += '&tryConversion=false'
+  if (options.tryConversion === false) url += '&tryConversion=false'
   // The API returns json with an extra layer of nesting, so remove it
   return fetchJSON(url).then(result => result[fsym])
 }

--- a/index.js
+++ b/index.js
@@ -18,10 +18,11 @@ function price (fsym, tsyms, tryConversion) {
   return fetchJSON(url)
 }
 
-function priceHistorical (fsym, tsyms, time) {
+function priceHistorical (fsym, tsyms, time, tryConversion) {
   if (!(time instanceof Date)) throw new Error('time parameter must be an instance of Date.')
   time = Math.floor(time.getTime() / 1000)
   let url = `${baseUrl}pricehistorical?fsym=${fsym}&tsyms=${tsyms}&ts=${time}`
+  if (tryConversion === false) url += '&tryConversion=false'
   // The API returns json with an extra layer of nesting, so remove it
   return fetchJSON(url).then(result => result[fsym])
 }

--- a/index.js
+++ b/index.js
@@ -74,6 +74,17 @@ function histoHour (fsym, tsym, options) {
   return fetchJSON(url).then(result => result.Data)
 }
 
+function histoMinute (fsym, tsym, options) {
+  options = options || {}
+  if (options.timestamp) options.timestamp = dateToTimestamp(options.timestamp)
+  let url = `${baseUrl}histominute?fsym=${fsym}&tsym=${tsym}`
+  if (options.limit) url += `&limit=${options.limit}`
+  if (options.tryConversion === false) url += '&tryConversion=false'
+  if (options.aggregate) url += `&aggregate=${options.aggregate}`
+  if (options.timestamp) url += `&toTs=${options.timestamp}`
+  return fetchJSON(url).then(result => result.Data)
+}
+
 function dateToTimestamp (date) {
   if (!(date instanceof Date)) throw new Error('timestamp must be an instance of Date.')
   return Math.floor(date.getTime() / 1000)
@@ -87,5 +98,6 @@ module.exports = {
   topPairs,
   topExchanges,
   histoDay,
-  histoHour
+  histoHour,
+  histoMinute
 }

--- a/index.js
+++ b/index.js
@@ -46,10 +46,17 @@ function topPairs (fsym, limit) {
   return fetchJSON(url).then(result => result.Data)
 }
 
+function topExchanges (fsym, tsym, limit) {
+  let url = `${baseUrl}top/exchanges?fsym=${fsym}&tsym=${tsym}`
+  if (limit) url += `&limit=${limit}`
+  return fetchJSON(url).then(result => result.Data)
+}
+
 module.exports = {
   price,
   priceMulti,
   priceFull,
   priceHistorical,
-  topPairs
+  topPairs,
+  topExchanges
 }

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function fetchJSON (url) {
 function price (fsym, tsyms, options) {
   options = options || {}
   let url = `${baseUrl}price?fsym=${fsym}&tsyms=${tsyms}`
+  if (options.exchanges) url += `&e=${options.exchanges}`
   if (options.tryConversion === false) url += '&tryConversion=false'
   return fetchJSON(url)
 }
@@ -22,6 +23,7 @@ function price (fsym, tsyms, options) {
 function priceMulti (fsyms, tsyms, options) {
   options = options || {}
   let url = `${baseUrl}pricemulti?fsyms=${fsyms}&tsyms=${tsyms}`
+  if (options.exchanges) url += `&e=${options.exchanges}`
   if (options.tryConversion === false) url += '&tryConversion=false'
   return fetchJSON(url)
 }
@@ -29,6 +31,7 @@ function priceMulti (fsyms, tsyms, options) {
 function priceFull (fsyms, tsyms, options) {
   options = options || {}
   let url = `${baseUrl}pricemultifull?fsyms=${fsyms}&tsyms=${tsyms}`
+  if (options.exchanges) url += `&e=${options.exchanges}`
   if (options.tryConversion === false) url += '&tryConversion=false'
   // We want the RAW data, not the DISPLAY data:
   return fetchJSON(url).then(result => result.RAW)
@@ -38,6 +41,7 @@ function priceHistorical (fsym, tsyms, time, options) {
   options = options || {}
   time = dateToTimestamp(time)
   let url = `${baseUrl}pricehistorical?fsym=${fsym}&tsyms=${tsyms}&ts=${time}`
+  if (options.exchanges) url += `&e=${options.exchanges}`
   if (options.tryConversion === false) url += '&tryConversion=false'
   // The API returns json with an extra layer of nesting, so remove it
   return fetchJSON(url).then(result => result[fsym])

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
+'use strict'
 /* global fetch */
 
-var baseUrl = 'https://www.cryptocompare.com/api/data/'
+const baseUrl = 'https://www.cryptocompare.com/api/data/'
 
 function fetchJSON (url) {
   return fetch(url)
@@ -13,22 +14,20 @@ function fetchJSON (url) {
 }
 
 function coinList () {
-  var url = baseUrl + 'coinlist/'
+  let url = `${baseUrl}coinlist/`
   return fetchJSON(url)
 }
 
 function price (fsym, tsyms, useBtc) {
-  if (!Array.isArray(tsyms)) tsyms = [tsyms]
-  var url = baseUrl + 'price?fsym=' + fsym + '&tsyms=' + tsyms.join(',')
+  let url = `${baseUrl}price?fsym=${fsym}&tsyms=${tsyms}`
   if (useBtc) url += 'usebtc=true'
   return fetchJSON(url)
 }
 
 function priceHistorical (fsym, tsyms, time) {
-  if (!Array.isArray(tsyms)) tsyms = [tsyms]
   if (!(time instanceof Date)) throw new Error('time parameter must be an instance of Date.')
   time = Math.floor(time.getTime() / 1000)
-  var url = baseUrl + 'pricehistorical?fsym=' + fsym + '&tsyms=' + tsyms.join(',') + '&ts=' + time
+  let url = `${baseUrl}pricehistorical?fsym=${fsym}&tsyms=${tsyms}&ts=${time}`
   return fetchJSON(url)
 }
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function price (fsym, tsyms, useBtc) {
 
 function priceHistorical (fsym, tsyms, time) {
   if (!Array.isArray(tsyms)) tsyms = [tsyms]
-  if (!time instanceof Date) throw new Error('time parameter must be an instance of Date.')
+  if (!(time instanceof Date)) throw new Error('time parameter must be an instance of Date.')
   time = Math.floor(time.getTime() / 1000)
   var url = baseUrl + 'pricehistorical?fsym=' + fsym + '&tsyms=' + tsyms.join(',') + '&ts=' + time
   return fetchJSON(url)

--- a/index.js
+++ b/index.js
@@ -52,11 +52,27 @@ function topExchanges (fsym, tsym, limit) {
   return fetchJSON(url).then(result => result.Data)
 }
 
+function histoDay (fsym, tsym, options) {
+  options = options || {}
+  if (options.timestamp) {
+    if (!(options.timestamp instanceof Date)) throw new Error('options.timestamp must be an instance of Date.')
+    options.timestamp = Math.floor(options.timestamp.getTime() / 1000)
+  }
+  let url = `${baseUrl}histoday?fsym=${fsym}&tsym=${tsym}`
+  if (options.limit === 'none') url += '&allData=true'
+  else if (options.limit) url += `&limit=${options.limit}`
+  if (options.tryConversion === false) url += '&tryConversion=false'
+  if (options.aggregate) url += `&aggregate=${options.aggregate}`
+  if (options.timestamp) url += `&toTs=${options.timestamp}`
+  return fetchJSON(url).then(result => result.Data)
+}
+
 module.exports = {
   price,
   priceMulti,
   priceFull,
   priceHistorical,
   topPairs,
-  topExchanges
+  topExchanges,
+  histoDay
 }

--- a/index.js
+++ b/index.js
@@ -39,6 +39,12 @@ function priceHistorical (fsym, tsyms, time, tryConversion) {
   return fetchJSON(url).then(result => result[fsym])
 }
 
+function generateAvg (fsym, tsym, markets, tryConversion) {
+  let url = `${baseUrl}generateAvg?fsym=${fsym}&tsym=${tsym}&markets=${markets}`
+  if (tryConversion === false) url += '&tryConversion=false'
+  return fetchJSON(url).then(result => result.RAW)
+}
+
 function topPairs (fsym, limit) {
   let url = `${baseUrl}top/pairs?fsym=${fsym}`
   if (limit) url += `&limit=${limit}`
@@ -95,6 +101,7 @@ module.exports = {
   priceMulti,
   priceFull,
   priceHistorical,
+  generateAvg,
   topPairs,
   topExchanges,
   histoDay,

--- a/index.js
+++ b/index.js
@@ -67,6 +67,20 @@ function histoDay (fsym, tsym, options) {
   return fetchJSON(url).then(result => result.Data)
 }
 
+function histoHour (fsym, tsym, options) {
+  options = options || {}
+  if (options.timestamp) {
+    if (!(options.timestamp instanceof Date)) throw new Error('options.timestamp must be an instance of Date.')
+    options.timestamp = Math.floor(options.timestamp.getTime() / 1000)
+  }
+  let url = `${baseUrl}histohour?fsym=${fsym}&tsym=${tsym}`
+  if (options.limit) url += `&limit=${options.limit}`
+  if (options.tryConversion === false) url += '&tryConversion=false'
+  if (options.aggregate) url += `&aggregate=${options.aggregate}`
+  if (options.timestamp) url += `&toTs=${options.timestamp}`
+  return fetchJSON(url).then(result => result.Data)
+}
+
 module.exports = {
   price,
   priceMulti,
@@ -74,5 +88,6 @@ module.exports = {
   priceHistorical,
   topPairs,
   topExchanges,
-  histoDay
+  histoDay,
+  histoHour
 }

--- a/index.js
+++ b/index.js
@@ -1,26 +1,20 @@
 'use strict'
 /* global fetch */
 
-const baseUrl = 'https://www.cryptocompare.com/api/data/'
+const baseUrl = 'https://min-api.cryptocompare.com/data/'
 
 function fetchJSON (url) {
   return fetch(url)
     .then(res => res.json())
     .then(body => {
-      // 'response' is a CryptoCompare field
-      if (body.Response !== 'Success') throw new Error(body.Message)
-      return body.Data
+      if (body.Response === 'Error') throw body.Message
+      return body
     })
 }
 
-function coinList () {
-  let url = `${baseUrl}coinlist/`
-  return fetchJSON(url)
-}
-
-function price (fsym, tsyms, useBtc) {
+function price (fsym, tsyms, tryConversion) {
   let url = `${baseUrl}price?fsym=${fsym}&tsyms=${tsyms}`
-  if (useBtc) url += 'usebtc=true'
+  if (tryConversion === false) url += '&tryConversion=false'
   return fetchJSON(url)
 }
 
@@ -28,11 +22,11 @@ function priceHistorical (fsym, tsyms, time) {
   if (!(time instanceof Date)) throw new Error('time parameter must be an instance of Date.')
   time = Math.floor(time.getTime() / 1000)
   let url = `${baseUrl}pricehistorical?fsym=${fsym}&tsyms=${tsyms}&ts=${time}`
-  return fetchJSON(url)
+  // The API returns json with an extra layer of nesting, so remove it
+  return fetchJSON(url).then(result => result[fsym])
 }
 
 module.exports = {
-  coinList,
   price,
   priceHistorical
 }

--- a/index.js
+++ b/index.js
@@ -24,6 +24,13 @@ function priceMulti (fsyms, tsyms, tryConversion) {
   return fetchJSON(url)
 }
 
+function priceFull (fsyms, tsyms, tryConversion) {
+  let url = `${baseUrl}pricemultifull?fsyms=${fsyms}&tsyms=${tsyms}`
+  if (tryConversion === false) url += '&tryConversion=false'
+  // We want the RAW data, not the DISPLAY data:
+  return fetchJSON(url).then(result => result.RAW)
+}
+
 function priceHistorical (fsym, tsyms, time, tryConversion) {
   if (!(time instanceof Date)) throw new Error('time parameter must be an instance of Date.')
   time = Math.floor(time.getTime() / 1000)
@@ -36,5 +43,6 @@ function priceHistorical (fsym, tsyms, time, tryConversion) {
 module.exports = {
   price,
   priceMulti,
+  priceFull,
   priceHistorical
 }

--- a/index.js
+++ b/index.js
@@ -32,8 +32,7 @@ function priceFull (fsyms, tsyms, tryConversion) {
 }
 
 function priceHistorical (fsym, tsyms, time, tryConversion) {
-  if (!(time instanceof Date)) throw new Error('time parameter must be an instance of Date.')
-  time = Math.floor(time.getTime() / 1000)
+  time = dateToTimestamp(time)
   let url = `${baseUrl}pricehistorical?fsym=${fsym}&tsyms=${tsyms}&ts=${time}`
   if (tryConversion === false) url += '&tryConversion=false'
   // The API returns json with an extra layer of nesting, so remove it
@@ -54,10 +53,7 @@ function topExchanges (fsym, tsym, limit) {
 
 function histoDay (fsym, tsym, options) {
   options = options || {}
-  if (options.timestamp) {
-    if (!(options.timestamp instanceof Date)) throw new Error('options.timestamp must be an instance of Date.')
-    options.timestamp = Math.floor(options.timestamp.getTime() / 1000)
-  }
+  if (options.timestamp) options.timestamp = dateToTimestamp(options.timestamp)
   let url = `${baseUrl}histoday?fsym=${fsym}&tsym=${tsym}`
   if (options.limit === 'none') url += '&allData=true'
   else if (options.limit) url += `&limit=${options.limit}`
@@ -69,16 +65,18 @@ function histoDay (fsym, tsym, options) {
 
 function histoHour (fsym, tsym, options) {
   options = options || {}
-  if (options.timestamp) {
-    if (!(options.timestamp instanceof Date)) throw new Error('options.timestamp must be an instance of Date.')
-    options.timestamp = Math.floor(options.timestamp.getTime() / 1000)
-  }
+  if (options.timestamp) options.timestamp = dateToTimestamp(options.timestamp)
   let url = `${baseUrl}histohour?fsym=${fsym}&tsym=${tsym}`
   if (options.limit) url += `&limit=${options.limit}`
   if (options.tryConversion === false) url += '&tryConversion=false'
   if (options.aggregate) url += `&aggregate=${options.aggregate}`
   if (options.timestamp) url += `&toTs=${options.timestamp}`
   return fetchJSON(url).then(result => result.Data)
+}
+
+function dateToTimestamp (date) {
+  if (!(date instanceof Date)) throw new Error('timestamp must be an instance of Date.')
+  return Math.floor(date.getTime() / 1000)
 }
 
 module.exports = {

--- a/test/cryptocompare.test.js
+++ b/test/cryptocompare.test.js
@@ -106,6 +106,27 @@ test("priceHistorical()'s tryConversion=false works", t => {
   testTryConversion(cc.priceHistorical(NOT_USD_TRADABLE, 'USD', timestamp, false), t)
 })
 
+test('topPairs()', t => {
+  t.plan(3 * 5 + 1)
+  cc.topPairs('BTC').then(pairs => {
+    t.equal(pairs.length, 5, 'returns 5 pairs by default')
+    pairs.forEach(pair => {
+      t.is(typeof pair.toSymbol, 'string', 'pair.toSymbol is a string')
+      t.is(typeof pair.volume24h, 'number', 'pair.volume24hr is a number')
+      t.is(typeof pair.volume24hTo, 'number', 'pair.volume24hrTo is a number')
+    })
+    t.end()
+  }).catch(t.end)
+})
+
+test("topPairs()'s limit option works", t => {
+  t.plan(1)
+  cc.topPairs('BTC', 3).then(pairs => {
+    t.equal(pairs.length, 3, 'limit works')
+    t.end()
+  }).catch(t.end)
+})
+
 test('error handling', t => {
   cc.price('BTC').then(prices => {
     t.end('Promise should not resolve')

--- a/test/cryptocompare.test.js
+++ b/test/cryptocompare.test.js
@@ -24,12 +24,12 @@ test('price()', function (t) {
 
 test('priceHistorical()', function (t) {
   t.plan(5)
-  var oneYearAgo = new Date((Date.now() / 1000 - 31536000) * 1000)
-  cc.priceHistorical('BTC', ['USD', 'CNY'], oneYearAgo).then(prices => {
+  // Arbitrary timestamp; historical values are hard-coded into this test
+  var timestamp = new Date(1456149600 * 1000)
+  cc.priceHistorical('BTC', ['USD', 'CNY'], timestamp).then(prices => {
     t.strictEqual(prices[0].Symbol, 'USD', 'prices[0].Symbol === USD')
     t.strictEqual(typeof prices[0].Price, 'number', 'prices[0].Price is a number')
-    // t.is(prices[0].Price, 321.68)
-    t.is(prices[0].Price, 323.65)
+    t.is(prices[0].Price, 438.26)
     t.strictEqual(prices[1].Symbol, 'CNY')
     t.strictEqual(typeof prices[1].Price, 'number')
     t.end()

--- a/test/cryptocompare.test.js
+++ b/test/cryptocompare.test.js
@@ -26,6 +26,28 @@ test("price()'s tryConversion=false works", t => {
   helpers.testTryConversion(cc.price(helpers.NOT_USD_TRADABLE, 'USD', { tryConversion: false }), t)
 })
 
+test("price()'s exchanges option works", t => {
+  t.plan(1)
+  Promise.all([
+    cc.price('BTC', 'USD'),
+    cc.price('BTC', 'USD', { exchanges: ['Coinbase'] })
+  ]).then(data => {
+    t.notDeepEqual(data[0], data[1])
+    t.end()
+  })
+})
+
+test('exchanges option allows passing a string', t => {
+  t.plan(1)
+  Promise.all([
+    cc.price('BTC', 'USD'),
+    cc.price('BTC', 'USD', { exchanges: 'Coinbase' })
+  ]).then(data => {
+    t.notDeepEqual(data[0], data[1])
+    t.end()
+  })
+})
+
 test('priceMulti()', t => {
   t.plan(4)
   cc.priceMulti(['BTC', 'ETH'], ['USD', 'EUR']).then(prices => {
@@ -47,6 +69,17 @@ test('priceMulti() allows passing strings instead of arrays', t => {
 
 test("priceMulti()'s tryConversion=false works", t => {
   helpers.testTryConversion(cc.priceMulti(helpers.NOT_USD_TRADABLE, 'USD', { tryConversion: false }), t)
+})
+
+test("priceMulti()'s exchanges option works", t => {
+  t.plan(1)
+  Promise.all([
+    cc.priceMulti('BTC', 'USD'),
+    cc.priceMulti('BTC', 'USD', { exchanges: ['Coinbase'] })
+  ]).then(data => {
+    t.notDeepEqual(data[0], data[1])
+    t.end()
+  })
 })
 
 test('priceFull()', t => {
@@ -83,6 +116,17 @@ test("priceFull()'s tryConversion=false works", t => {
   helpers.testTryConversion(cc.priceFull(helpers.NOT_USD_TRADABLE, 'USD', { tryConversion: false }), t)
 })
 
+test("priceFull()'s exchanges option works", t => {
+  t.plan(1)
+  Promise.all([
+    cc.priceFull('BTC', 'USD'),
+    cc.priceFull('BTC', 'USD', { exchanges: ['Coinbase'] })
+  ]).then(data => {
+    t.notDeepEqual(data[0], data[1])
+    t.end()
+  })
+})
+
 test('priceHistorical()', t => {
   t.plan(3)
   // NOTE: Historical values are hard-coded into this test
@@ -104,6 +148,18 @@ test("priceHistorical()'s tryConversion=false works", t => {
       timestamp,
       { tryConversion: false }
     ), t)
+})
+
+test("priceHistorical()'s exchanges option works", t => {
+  t.plan(1)
+  const timestamp = new Date()
+  Promise.all([
+    cc.priceHistorical('BTC', 'USD', timestamp),
+    cc.priceHistorical('BTC', 'USD', timestamp, { exchanges: ['Coinbase'] })
+  ]).then(data => {
+    t.notDeepEqual(data[0], data[1])
+    t.end()
+  })
 })
 
 test('generateAvg()', t => {

--- a/test/cryptocompare.test.js
+++ b/test/cryptocompare.test.js
@@ -51,6 +51,36 @@ test('priceMulti() allows passing strings instead of arrays', t => {
   }).catch(t.end)
 })
 
+test('priceFull()', t => {
+  t.plan(5 * 2 * 2)
+  cc.priceFull(['BTC', 'ETH'], ['USD', 'EUR']).then(prices => {
+    for (let fsym in prices) {
+      for (let tsym in prices[fsym]) {
+        t.is(typeof prices[fsym][tsym].PRICE, 'number', `prices.${fsym}.${tsym}.PRICE is a number`)
+        t.is(typeof prices[fsym][tsym].SUPPLY, 'number', `prices.${fsym}.${tsym}.SUPPLY is a number`)
+        t.is(typeof prices[fsym][tsym].MKTCAP, 'number', `prices.${fsym}.${tsym}.MKTCAP is a number`)
+
+        t.is(typeof prices[fsym][tsym].MARKET, 'string', `prices.${fsym}.${tsym}.MARKET is a string`)
+        t.is(typeof prices[fsym][tsym].LASTMARKET, 'string', `prices.${fsym}.${tsym}.LASTMARKET is a string`)
+      }
+    }
+    t.end()
+  }).catch(t.end)
+})
+
+test('priceFull() allows passing strings instead of arrays', t => {
+  t.plan(5)
+  cc.priceFull('BTC', 'USD').then(prices => {
+    t.is(typeof prices.BTC.USD.PRICE, 'number', `prices.BTC.USD.PRICE is a number`)
+    t.is(typeof prices.BTC.USD.SUPPLY, 'number', `prices.BTC.USD.SUPPLY is a number`)
+    t.is(typeof prices.BTC.USD.MKTCAP, 'number', `prices.BTC.USD.MKTCAP is a number`)
+
+    t.is(typeof prices.BTC.USD.MARKET, 'string', `prices.BTC.USD.MARKET is a string`)
+    t.is(typeof prices.BTC.USD.LASTMARKET, 'string', `prices.BTC.USD.LASTMARKET is a string`)
+    t.end()
+  }).catch(t.end)
+})
+
 test('priceHistorical()', t => {
   t.plan(3)
   // NOTE: Historical values are hard-coded into this test

--- a/test/cryptocompare.test.js
+++ b/test/cryptocompare.test.js
@@ -23,7 +23,7 @@ test('price() allows passing a string as the second parameter', t => {
 })
 
 test("price()'s tryConversion=false works", t => {
-  helpers.testTryConversion(cc.price(helpers.NOT_USD_TRADABLE, 'USD', false), t)
+  helpers.testTryConversion(cc.price(helpers.NOT_USD_TRADABLE, 'USD', { tryConversion: false }), t)
 })
 
 test('priceMulti()', t => {
@@ -46,7 +46,7 @@ test('priceMulti() allows passing strings instead of arrays', t => {
 })
 
 test("priceMulti()'s tryConversion=false works", t => {
-  helpers.testTryConversion(cc.priceMulti(helpers.NOT_USD_TRADABLE, 'USD', false), t)
+  helpers.testTryConversion(cc.priceMulti(helpers.NOT_USD_TRADABLE, 'USD', { tryConversion: false }), t)
 })
 
 test('priceFull()', t => {
@@ -80,7 +80,7 @@ test('priceFull() allows passing strings instead of arrays', t => {
 })
 
 test("priceFull()'s tryConversion=false works", t => {
-  helpers.testTryConversion(cc.priceFull(helpers.NOT_USD_TRADABLE, 'USD', false), t)
+  helpers.testTryConversion(cc.priceFull(helpers.NOT_USD_TRADABLE, 'USD', { tryConversion: false }), t)
 })
 
 test('priceHistorical()', t => {
@@ -97,7 +97,13 @@ test('priceHistorical()', t => {
 
 test("priceHistorical()'s tryConversion=false works", t => {
   const timestamp = new Date('2017-01-01')
-  helpers.testTryConversion(cc.priceHistorical(helpers.NOT_USD_TRADABLE, 'USD', timestamp, false), t)
+  helpers.testTryConversion(
+    cc.priceHistorical(
+      helpers.NOT_USD_TRADABLE,
+      'USD',
+      timestamp,
+      { tryConversion: false }
+    ), t)
 })
 
 test('generateAvg()', t => {

--- a/test/cryptocompare.test.js
+++ b/test/cryptocompare.test.js
@@ -127,6 +127,32 @@ test("topPairs()'s limit option works", t => {
   }).catch(t.end)
 })
 
+test('topExchanges()', t => {
+  t.plan(6 * 5 + 1)
+  cc.topExchanges('BTC', 'USD').then(exchanges => {
+    let prev
+    t.equal(exchanges.length, 5, 'returns 5 pairs by default')
+    exchanges.forEach(item => {
+      t.is(typeof item.exchange, 'string', 'item.exchange is a string')
+      t.notEqual(item.exchange, prev, 'item.exchange is unique')
+      prev = item.exchange
+      t.is(typeof item.fromSymbol, 'string', 'item.fromSymbol is a string')
+      t.is(typeof item.toSymbol, 'string', 'item.toSymbol is a string')
+      t.is(typeof item.volume24h, 'number', 'item.volume24hr is a number')
+      t.is(typeof item.volume24hTo, 'number', 'item.volume24hrTo is a number')
+    })
+    t.end()
+  }).catch(t.end)
+})
+
+test("topExchanges()'s limit option works", t => {
+  t.plan(1)
+  cc.topExchanges('BTC', 'USD', 3).then(exchanges => {
+    t.equal(exchanges.length, 3, 'limit works')
+    t.end()
+  }).catch(t.end)
+})
+
 test('error handling', t => {
   cc.price('BTC').then(prices => {
     t.end('Promise should not resolve')

--- a/test/cryptocompare.test.js
+++ b/test/cryptocompare.test.js
@@ -1,17 +1,18 @@
-var test = require('tape')
+'use strict'
+const test = require('tape')
 
 // set to global
 global.fetch = require('node-fetch')
-var cc = require('../')
+const cc = require('../')
 
-test('coinList()', function (t) {
+test('coinList()', t => {
   t.plan(1)
   cc.coinList().then(coinList => {
     t.strictEqual(coinList.BTC.CoinName, 'Bitcoin', 'CoinName field should be Bitcoin')
   }).catch(t.end)
 })
 
-test('price()', function (t) {
+test('price()', t => {
   t.plan(4)
   cc.price('BTC', ['USD', 'CNY']).then(prices => {
     t.strictEqual(prices[0].Symbol, 'USD', 'prices[0].Symbol === USD')
@@ -22,10 +23,10 @@ test('price()', function (t) {
   }).catch(t.end)
 })
 
-test('priceHistorical()', function (t) {
+test('priceHistorical()', t => {
   t.plan(5)
   // Arbitrary timestamp; historical values are hard-coded into this test
-  var timestamp = new Date(1456149600 * 1000)
+  const timestamp = new Date(1456149600 * 1000)
   cc.priceHistorical('BTC', ['USD', 'CNY'], timestamp).then(prices => {
     t.strictEqual(prices[0].Symbol, 'USD', 'prices[0].Symbol === USD')
     t.strictEqual(typeof prices[0].Price, 'number', 'prices[0].Price is a number')

--- a/test/cryptocompare.test.js
+++ b/test/cryptocompare.test.js
@@ -23,10 +23,11 @@ test('price() allows passing a string as the second parameter', t => {
 })
 
 test("price()'s tryConversion=false works", t => {
+  t.plan(1)
   cc.price('LTD', 'USD', false).then(prices => {
     t.end('Promise should not resolve')
   }).catch(e => {
-    t.ok(e, 'Converting LTD to USD fails')
+    t.ok(e.match(/market does not exist/i), 'Converting LTD to USD fails')
     t.end()
   }).catch(t.end)
 })
@@ -39,6 +40,18 @@ test('priceHistorical()', t => {
     t.strictEqual(typeof prices.USD, 'number', 'prices.USD is a number')
     t.is(prices.USD, 997, 'Correct historical value')
     t.strictEqual(typeof prices.EUR, 'number', 'prices.EUR is a number')
+    t.end()
+  }).catch(t.end)
+})
+
+test("priceHistorical()'s tryConversion=false works", t => {
+  t.plan(1)
+  // NOTE: Historical values are hard-coded into this test
+  const timestamp = new Date('2017-01-01')
+  cc.priceHistorical('LTD', 'USD', timestamp, false).then(prices => {
+    t.end('Promise should not resolve')
+  }).catch(e => {
+    t.ok(e.match(/market does not exist/i), 'Converting LTD to USD fails')
     t.end()
   }).catch(t.end)
 })

--- a/test/cryptocompare.test.js
+++ b/test/cryptocompare.test.js
@@ -32,6 +32,25 @@ test("price()'s tryConversion=false works", t => {
   }).catch(t.end)
 })
 
+test('priceMulti()', t => {
+  t.plan(4)
+  cc.priceMulti(['BTC', 'ETH'], ['USD', 'EUR']).then(prices => {
+    t.strictEqual(typeof prices.BTC.USD, 'number', 'prices.BTC.USD is a number')
+    t.strictEqual(typeof prices.BTC.EUR, 'number', 'prices.BTC.EUR is a number')
+    t.strictEqual(typeof prices.ETH.USD, 'number', 'prices.ETH.USD is a number')
+    t.strictEqual(typeof prices.ETH.EUR, 'number', 'prices.ETH.EUR is a number')
+    t.end()
+  }).catch(t.end)
+})
+
+test('priceMulti() allows passing strings instead of arrays', t => {
+  t.plan(1)
+  cc.priceMulti('BTC', 'USD').then(prices => {
+    t.strictEqual(typeof prices.BTC.USD, 'number', 'prices.BTC.USD is a number')
+    t.end()
+  }).catch(t.end)
+})
+
 test('priceHistorical()', t => {
   t.plan(3)
   // NOTE: Historical values are hard-coded into this test

--- a/test/cryptocompare.test.js
+++ b/test/cryptocompare.test.js
@@ -5,34 +5,49 @@ const test = require('tape')
 global.fetch = require('node-fetch')
 const cc = require('../')
 
-test('coinList()', t => {
-  t.plan(1)
-  cc.coinList().then(coinList => {
-    t.strictEqual(coinList.BTC.CoinName, 'Bitcoin', 'CoinName field should be Bitcoin')
+test('price()', t => {
+  t.plan(2)
+  cc.price('BTC', ['USD', 'EUR']).then(prices => {
+    t.strictEqual(typeof prices.USD, 'number', 'prices.USD is a number')
+    t.strictEqual(typeof prices.EUR, 'number', 'prices.EUR is a number')
+    t.end()
   }).catch(t.end)
 })
 
-test('price()', t => {
-  t.plan(4)
-  cc.price('BTC', ['USD', 'CNY']).then(prices => {
-    t.strictEqual(prices[0].Symbol, 'USD', 'prices[0].Symbol === USD')
-    t.strictEqual(typeof prices[0].Price, 'number', 'prices[0].Price is a number')
-    t.strictEqual(prices[1].Symbol, 'CNY')
-    t.strictEqual(typeof prices[1].Price, 'number')
+test('price() allows passing a string as the second parameter', t => {
+  t.plan(1)
+  cc.price('BTC', 'USD').then(prices => {
+    t.strictEqual(typeof prices.USD, 'number', 'prices.USD is a number')
+    t.end()
+  }).catch(t.end)
+})
+
+test("price()'s tryConversion=false works", t => {
+  cc.price('LTD', 'USD', false).then(prices => {
+    t.end('Promise should not resolve')
+  }).catch(e => {
+    t.ok(e, 'Converting LTD to USD fails')
     t.end()
   }).catch(t.end)
 })
 
 test('priceHistorical()', t => {
-  t.plan(5)
-  // Arbitrary timestamp; historical values are hard-coded into this test
-  const timestamp = new Date(1456149600 * 1000)
-  cc.priceHistorical('BTC', ['USD', 'CNY'], timestamp).then(prices => {
-    t.strictEqual(prices[0].Symbol, 'USD', 'prices[0].Symbol === USD')
-    t.strictEqual(typeof prices[0].Price, 'number', 'prices[0].Price is a number')
-    t.is(prices[0].Price, 438.26)
-    t.strictEqual(prices[1].Symbol, 'CNY')
-    t.strictEqual(typeof prices[1].Price, 'number')
+  t.plan(3)
+  // NOTE: Historical values are hard-coded into this test
+  const timestamp = new Date('2017-01-01')
+  cc.priceHistorical('BTC', ['USD', 'EUR'], timestamp).then(prices => {
+    t.strictEqual(typeof prices.USD, 'number', 'prices.USD is a number')
+    t.is(prices.USD, 997, 'Correct historical value')
+    t.strictEqual(typeof prices.EUR, 'number', 'prices.EUR is a number')
+    t.end()
+  }).catch(t.end)
+})
+
+test('error handling', t => {
+  cc.price('BTC').then(prices => {
+    t.end('Promise should not resolve')
+  }).catch(e => {
+    t.ok(e, 'Errors')
     t.end()
   }).catch(t.end)
 })

--- a/test/cryptocompare.test.js
+++ b/test/cryptocompare.test.js
@@ -100,6 +100,26 @@ test("priceHistorical()'s tryConversion=false works", t => {
   helpers.testTryConversion(cc.priceHistorical(helpers.NOT_USD_TRADABLE, 'USD', timestamp, false), t)
 })
 
+test('generateAvg()', t => {
+  t.plan(6)
+  cc.generateAvg('BTC', 'USD', ['Coinbase', 'Kraken', 'Bitstamp', 'Bitfinex']).then(data => {
+    t.is(typeof data.PRICE, 'number', `data.PRICE is a number`)
+    t.is(typeof data.VOLUME24HOUR, 'number', `data.VOLUME24HOUR is a number`)
+    t.is(typeof data.VOLUME24HOURTO, 'number', `data.VOLUME24HOURTo is a number`)
+    t.is(typeof data.OPEN24HOUR, 'number', `data.OPEN24HOUR is a number`)
+    t.is(typeof data.HIGH24HOUR, 'number', `data.OPEN24HOUR is a number`)
+    t.is(typeof data.LOW24HOUR, 'number', `data.OPEN24HOUR is a number`)
+    t.end()
+  }).catch(t.end)
+})
+
+test("generateAvg()'s tryConversion=false works", t => {
+  helpers.testTryConversion(
+    cc.generateAvg(helpers.NOT_USD_TRADABLE, 'USD', ['Coinbase', 'Kraken'], false),
+    t
+  )
+})
+
 test('topPairs()', t => {
   t.plan(3 * 5 + 1)
   cc.topPairs('BTC').then(pairs => {

--- a/test/cryptocompare.test.js
+++ b/test/cryptocompare.test.js
@@ -153,6 +153,45 @@ test("topExchanges()'s limit option works", t => {
   }).catch(t.end)
 })
 
+test('histoDay()', t => {
+  t.plan(8)
+  cc.histoDay('BTC', 'USD').then(data => {
+    t.is(data.length, 31, 'returns 31 items by default')
+    const item = data[0]
+    t.is(typeof item.time, 'number', 'item.time is a number')
+    t.is(typeof item.close, 'number', 'item.close is a number')
+    t.is(typeof item.high, 'number', 'item.high is a number')
+    t.is(typeof item.low, 'number', 'item.low is a number')
+    t.is(typeof item.open, 'number', 'item.open is a number')
+    t.is(typeof item.volumefrom, 'number', 'item.volumefrom is a number')
+    t.is(typeof item.volumeto, 'number', 'item.volumeto is a number')
+    t.end()
+  }).catch(t.end)
+})
+
+test("histoDay()'s limit option works", t => {
+  t.plan(1)
+  cc.histoDay('BTC', 'USD', { limit: 2 }).then(data => {
+    t.is(data.length, 3, 'returns limit plus timestamped data')
+    t.end()
+  }).catch(t.end)
+})
+
+test("histoDay()'s timestamp option works", t => {
+  t.plan(1)
+  let data = []
+  data.push(cc.histoDay('BTC', 'USD', { timestamp: new Date('2017-01-01') }))
+  data.push(cc.histoDay('BTC', 'USD', { timestamp: new Date('2017-01-02') }))
+  Promise.all(data).then(data => {
+    t.notDeepEqual(data[0], data[1], 'data from different days should not be equivalent')
+    t.end()
+  }).catch(t.end)
+})
+
+test("histoDay()'s tryConversion=false works", t => {
+  testTryConversion(cc.histoDay(NOT_USD_TRADABLE, 'USD', { tryConversion: false }), t)
+})
+
 test('error handling', t => {
   cc.price('BTC').then(prices => {
     t.end('Promise should not resolve')

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,0 +1,17 @@
+'use strict'
+
+// NOT_USD_TRADABLE is a cryptocurrency which does not trade directly with USD.
+// This value is used in testing tryConversion. Currently, this is set to LTD.
+// If LTD trades directly with USD in the future, tests will fail.
+// In that case, change this value:
+exports.NOT_USD_TRADABLE = 'LTD'
+
+exports.testTryConversion = function (promise, t) {
+  t.plan(1)
+  promise.then(prices => {
+    t.end('Promise should not resolve')
+  }).catch(e => {
+    t.ok(e.match(/market does not exist/i), `Converting ${exports.NOT_USD_TRADABLE} to USD fails`)
+    t.end()
+  }).catch(t.end)
+}

--- a/test/histo.test.js
+++ b/test/histo.test.js
@@ -1,0 +1,45 @@
+'use strict'
+const test = require('tape')
+
+if (!global.fetch) global.fetch = require('node-fetch')
+const cc = require('../')
+const helpers = require('./helpers')
+
+test('histoDay()', t => {
+  t.plan(8)
+  cc.histoDay('BTC', 'USD').then(data => {
+    t.is(data.length, 31, 'returns 31 items by default')
+    const item = data[0]
+    t.is(typeof item.time, 'number', 'item.time is a number')
+    t.is(typeof item.close, 'number', 'item.close is a number')
+    t.is(typeof item.high, 'number', 'item.high is a number')
+    t.is(typeof item.low, 'number', 'item.low is a number')
+    t.is(typeof item.open, 'number', 'item.open is a number')
+    t.is(typeof item.volumefrom, 'number', 'item.volumefrom is a number')
+    t.is(typeof item.volumeto, 'number', 'item.volumeto is a number')
+    t.end()
+  }).catch(t.end)
+})
+
+test("histoDay()'s limit option works", t => {
+  t.plan(1)
+  cc.histoDay('BTC', 'USD', { limit: 2 }).then(data => {
+    t.is(data.length, 3, 'returns limit plus timestamped data')
+    t.end()
+  }).catch(t.end)
+})
+
+test("histoDay()'s timestamp option works", t => {
+  t.plan(1)
+  let data = []
+  data.push(cc.histoDay('BTC', 'USD', { timestamp: new Date('2017-01-01') }))
+  data.push(cc.histoDay('BTC', 'USD', { timestamp: new Date('2017-01-02') }))
+  Promise.all(data).then(data => {
+    t.notDeepEqual(data[0], data[1], 'data from different days should not be equivalent')
+    t.end()
+  }).catch(t.end)
+})
+
+test("histoDay()'s tryConversion=false works", t => {
+  helpers.testTryConversion(cc.histoDay(helpers.NOT_USD_TRADABLE, 'USD', { tryConversion: false }), t)
+})

--- a/test/histo.test.js
+++ b/test/histo.test.js
@@ -43,3 +43,42 @@ test("histoDay()'s timestamp option works", t => {
 test("histoDay()'s tryConversion=false works", t => {
   helpers.testTryConversion(cc.histoDay(helpers.NOT_USD_TRADABLE, 'USD', { tryConversion: false }), t)
 })
+
+test('histoHour()', t => {
+  t.plan(8)
+  cc.histoHour('BTC', 'USD').then(data => {
+    t.is(data.length, 169, 'returns 169 items by default')
+    const item = data[0]
+    t.is(typeof item.time, 'number', 'item.time is a number')
+    t.is(typeof item.close, 'number', 'item.close is a number')
+    t.is(typeof item.high, 'number', 'item.high is a number')
+    t.is(typeof item.low, 'number', 'item.low is a number')
+    t.is(typeof item.open, 'number', 'item.open is a number')
+    t.is(typeof item.volumefrom, 'number', 'item.volumefrom is a number')
+    t.is(typeof item.volumeto, 'number', 'item.volumeto is a number')
+    t.end()
+  }).catch(t.end)
+})
+
+test("histoHour()'s limit option works", t => {
+  t.plan(1)
+  cc.histoHour('BTC', 'USD', { limit: 2 }).then(data => {
+    t.is(data.length, 3, 'returns limit plus timestamped data')
+    t.end()
+  }).catch(t.end)
+})
+
+test("histoHour()'s timestamp option works", t => {
+  t.plan(1)
+  let data = []
+  data.push(cc.histoHour('BTC', 'USD', { timestamp: new Date('2017-01-01') }))
+  data.push(cc.histoHour('BTC', 'USD', { timestamp: new Date('2017-01-02') }))
+  Promise.all(data).then(data => {
+    t.notDeepEqual(data[0], data[1], 'data from different days should not be equivalent')
+    t.end()
+  }).catch(t.end)
+})
+
+test("histoHour()'s tryConversion=false works", t => {
+  helpers.testTryConversion(cc.histoHour(helpers.NOT_USD_TRADABLE, 'USD', { tryConversion: false }), t)
+})

--- a/test/histo.test.js
+++ b/test/histo.test.js
@@ -82,3 +82,42 @@ test("histoHour()'s timestamp option works", t => {
 test("histoHour()'s tryConversion=false works", t => {
   helpers.testTryConversion(cc.histoHour(helpers.NOT_USD_TRADABLE, 'USD', { tryConversion: false }), t)
 })
+
+test('histoMinute()', t => {
+  t.plan(8)
+  cc.histoMinute('BTC', 'USD').then(data => {
+    t.is(data.length, 1441, 'returns 1441 items by default')
+    const item = data[0]
+    t.is(typeof item.time, 'number', 'item.time is a number')
+    t.is(typeof item.close, 'number', 'item.close is a number')
+    t.is(typeof item.high, 'number', 'item.high is a number')
+    t.is(typeof item.low, 'number', 'item.low is a number')
+    t.is(typeof item.open, 'number', 'item.open is a number')
+    t.is(typeof item.volumefrom, 'number', 'item.volumefrom is a number')
+    t.is(typeof item.volumeto, 'number', 'item.volumeto is a number')
+    t.end()
+  }).catch(t.end)
+})
+
+test("histoMinute()'s limit option works", t => {
+  t.plan(1)
+  cc.histoMinute('BTC', 'USD', { limit: 2 }).then(data => {
+    t.is(data.length, 3, 'returns limit plus timestamped data')
+    t.end()
+  }).catch(t.end)
+})
+
+test("histoMinute()'s timestamp option works", t => {
+  t.plan(1)
+  let data = []
+  data.push(cc.histoMinute('BTC', 'USD', { timestamp: new Date('2017-01-01') }))
+  data.push(cc.histoMinute('BTC', 'USD', { timestamp: new Date('2017-01-02') }))
+  Promise.all(data).then(data => {
+    t.notDeepEqual(data[0], data[1], 'data from different days should not be equivalent')
+    t.end()
+  }).catch(t.end)
+})
+
+test("histoMinute()'s tryConversion=false works", t => {
+  helpers.testTryConversion(cc.histoMinute(helpers.NOT_USD_TRADABLE, 'USD', { tryConversion: false }), t)
+})


### PR DESCRIPTION
Summary of changes:

- Switched to https://min-api.cryptocompare.com/
- removed: `coinList()`
- changed: `price()` returns a different data structure
- changed: `priceHistorical()` returns a different data structure
- changed: `price()` and `priceHistorical)()` function signature has changed
- added: `priceMulti()`
- added: `priceFull()`
- added: `topPairs()`
- added: `topExchanges()`
- added: `histoDay()`
- added: `histoHour()`
- added: `histoMinute()`
- added: `generateAvg()`
- added: `exchanges` option for methods that support it