### PR TITLE
 Create function exchangeList() to get list of exchanges

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,37 @@ cc.coinList()
 .catch(console.error)
 ```
 
+### `exchangeList()`
+
+Returns all the exchanges that CryptoCompare has integrated with.
+
+`exchangeList()`
+
+- `No parameters`
+- `Returns` (Object)
+
+```js
+const cc = require('cryptocompare')
+
+// Usage:
+cc.exchangeList()
+.then(exchangeList => {
+  console.log(exchangeList)
+  // {
+  //   "Cryptsy":
+  //   {
+  //     "42":["BTC","XRP"],
+  //     "EMC2":["BTC","XRP"],
+  //     "POINTS":["BTC"],
+  //     "VTC":["BTC","LTC","XRP"]
+  //     ...
+  //   }
+  //   ...
+  // }
+})
+.catch(console.error)
+```
+
 ### `price()`
 
 Get the current price of any cryptocurrency in any other currency.

--- a/index.js
+++ b/index.js
@@ -17,6 +17,11 @@ function coinList () {
   return fetchJSON(url)
 }
 
+function exchangeList () {
+  const url = `${baseUrl}all/exchanges`
+  return fetchJSON(url)
+}
+
 function price (fsym, tsyms, options) {
   options = options || {}
   let url = `${baseUrl}price?fsym=${fsym}&tsyms=${tsyms}`
@@ -114,6 +119,7 @@ function dateToTimestamp (date) {
 
 module.exports = {
   coinList,
+  exchangeList,
   price,
   priceMulti,
   priceFull,

--- a/test/cryptocompare.test.js
+++ b/test/cryptocompare.test.js
@@ -16,6 +16,15 @@ test('coinList()', t => {
   }).catch(t.end)
 })
 
+test('exchangeList()', t => {
+  t.plan(2)
+  cc.exchangeList().then(exchanges => {
+    t.strictEqual(typeof exchanges, 'object', 'exchanges returned is an object')
+    t.notEqual(exchanges, null, 'exchanges returned is not null')
+    t.end()
+  }).catch(t.end)
+})
+
 test('price()', t => {
   t.plan(2)
   cc.price('BTC', ['USD', 'EUR']).then(prices => {


### PR DESCRIPTION
We needed to get a list of exchanges from CryptoCompare API. So adding a new function to the library.

- Exchange list is available at https://min-api.cryptocompare.com/data/all/exchanges
- Wrote tests for this function
- Add documentation for this function