### PR TITLE
handle http status errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,12 @@ const baseUrl = 'https://min-api.cryptocompare.com/data/'
 
 function fetchJSON (url) {
   return fetch(url)
+    .then(res => {
+      if (!res.ok) {
+        throw Error(res.status + " " + res.statusText)
+      }
+      return res
+    })
     .then(res => res.json())
     .then(body => {
       if (body.Response === 'Error') throw body.Message

--- a/index.js
+++ b/index.js
@@ -9,9 +9,8 @@ function fetchJSON (url) {
       if (!res.ok) {
         throw new Error(`${res.status} ${res.statusText}`)
       }
-      return res
+      return res.json()
     })
-    .then(res => res.json())
     .then(body => {
       if (body.Response === 'Error') throw body.Message
       return body

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function fetchJSON (url) {
   return fetch(url)
     .then(res => {
       if (!res.ok) {
-        throw Error(res.status + " " + res.statusText)
+        throw Error(res.status + ' ' + res.statusText)
       }
       return res
     })

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function fetchJSON (url) {
   return fetch(url)
     .then(res => {
       if (!res.ok) {
-        throw Error(res.status + ' ' + res.statusText)
+        throw new Error(`${res.status} ${res.statusText}`)
       }
       return res
     })


### PR DESCRIPTION
This change handles non-200 server errors from cryptocompare.com.  Instead of immediately trying to parse the response body as JSON it will first check the HTTP status code.