### PR TITLE
Add topExchangesFull api

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,12 @@ function topExchanges (fsym, tsym, limit) {
   return fetchJSON(url).then(result => result.Data)
 }
 
+function topExchangesFull (fsym, tsym, limit) {
+  let url = `${baseUrl}top/exchanges/full?fsym=${fsym}&tsym=${tsym}`
+  if (limit) url += `&limit=${limit}`
+  return fetchJSON(url).then(result => result.Data)
+}
+
 function histoDay (fsym, tsym, options) {
   options = options || {}
   if (options.timestamp) options.timestamp = dateToTimestamp(options.timestamp)
@@ -132,6 +138,7 @@ module.exports = {
   generateAvg,
   topPairs,
   topExchanges,
+  topExchangesFull,
   histoDay,
   histoHour,
   histoMinute


### PR DESCRIPTION
Fetch top exchanges full data by pair, the example url: https://min-api.cryptocompare.com/data/top/exchanges/full?fsym=BTC&tsym=USD. And the detailed doc
see: https://min-api.cryptocompare.com/