### PR TITLE
Omit Extra `data` in `newsList` and `newsFeedsAndCategories` URL Pathname

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,13 +41,13 @@ function exchangeList () {
 }
 
 function newsFeedsAndCategories () {
-  const url = `${baseUrl}data/news/feedsandcategories`
+  const url = `${baseUrl}news/feedsandcategories`
   return fetchJSON(url).then(result => result.Data)
 }
 
 function newsList (lang, options) {
   options = options || {}
-  let url = `${baseUrl}data/v2/news/?lang=${lang}`
+  let url = `${baseUrl}v2/news/?lang=${lang}`
   if (options.feeds) url += `&feeds=${options.feeds}`
   if (options.categories) url += `&categories=${options.categories}`
   if (options.excludeCategories) url += `&categories=${options.excludeCategories}`


### PR DESCRIPTION
`baseUrl` already contains `data` within its URL pathname. This PR omits the additional `data`.

Current:

<img src="https://www.dropbox.com/s/wfbzuvj02k76jw0/Screenshot%202019-01-14%2002.44.44.png?raw=1" />

<img src="https://www.dropbox.com/s/cx44ks9yb0hm1fn/Screenshot%202019-01-14%2002.45.23.png?raw=1" />

After Fix:

<img src="https://www.dropbox.com/s/cdzo98b491ccxqq/Screenshot%202019-01-14%2002.52.52.png?raw=1" />

<img src="https://www.dropbox.com/s/a92ugkp3cypdfn1/Screenshot%202019-01-14%2002.53.10.png?raw=1" />